### PR TITLE
Social buttons, specified in the config file

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,3 +3,13 @@ languageCode = 'nl-nl'
 title = 'Ontdek wat er werkelijk achter NAVO schuilgaat | Bunzing'
 description = ''
 theme = ["flow-theme"]
+
+
+[params]
+facebook = "https://www.facebook.com/profile.php?id=61575103342803"
+instagram =  "#"
+linkedin = "https://www.linkedin.com/company/bunzing/"
+
+spotify = "#"
+youtube = "#"
+apple =  "#"

--- a/themes/flow-theme/layouts/_partials/footer.html
+++ b/themes/flow-theme/layouts/_partials/footer.html
@@ -5,14 +5,14 @@
           >Bunzing</p>
             <div class="flex space-x-4">
               <!-- Facebook -->
-              <a href="#" class="text-lime-100 hover:text-red-500">
+              <a href="{{ .Site.Params.facebook }}" class="text-lime-100 hover:text-red-500">
                 <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path fill-rule="evenodd" d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z" clip-rule="evenodd" />
                 </svg>
               </a>
 
               <!-- Instagram -->
-              <a href="#" class="text-lime-100 hover:text-red-500">
+              <a href="{{ .Site.Params.instagram }}" class="text-lime-100 hover:text-red-500">
                 <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path
                     fill-rule="evenodd"
@@ -23,7 +23,7 @@
               </a>
               <!-- Linkedin -->
 
-              <a href="#" class="text-lime-100 hover:text-red-500">
+              <a href="{{ .Site.Params.linkedin }}" class="text-lime-100 hover:text-red-500">
                 <svg
                 xmlns="http://www.w3.org/2000/svg"
                 class="h-6 w-6" 

--- a/themes/flow-theme/layouts/_partials/platforms.html
+++ b/themes/flow-theme/layouts/_partials/platforms.html
@@ -10,7 +10,7 @@
     >
       <!-- Spotify -->
       <a
-        href="#"
+        href="{{ .Site.Params.spotify }}"
         class="flex justify-center items-center text-lime-100 hover:text-red-500"
       >
         <span class="flex flex-row justify-center items-center gap-2">
@@ -33,7 +33,7 @@
 
       <!-- Youtube -->
       <a
-        href="#"
+        href="{{ .Site.Params.youtube }}"
         class="flex justify-center items-center text-lime-100 hover:text-red-500"
       >
         <span class="flex flex-row justify-center items-center gap-2">
@@ -56,7 +56,7 @@
 
       <!-- Apple podcasts -->
       <a
-        href="#"
+        href="{{ .Site.Params.apple }}"
         class="flex justify-center items-center text-lime-100 hover:text-red-500"
       >
         <span class="flex flex-row justify-center items-center">
@@ -78,7 +78,7 @@
 
       <!-- RSS -->
       <a
-        href="#"
+        href="{{ .Site.BaseURL}}feed/mp3/index.xml"
         class="flex justify-center items-center text-lime-100 hover:text-red-500"
       >
         <span class="flex flex-row justify-center items-center gap-2">


### PR DESCRIPTION
Hi! I've added Linkedin and Facebook. I don't think we created the Instagram yet. The urls are now specified under `params` in the config file. I've done the same for the buttons to the podcast platforms. Only the RSS feed is not set in the params, but is hardcoded/constructed. 