### PR TITLE
Improved Opengraph, now also for the posts

### DIFF
--- a/themes/flow-theme/layouts/_partials/head.html
+++ b/themes/flow-theme/layouts/_partials/head.html
@@ -6,13 +6,31 @@
   async
 ></script>
 
+{{if eq .Section "posts"}}
+<!-- Open Graph preview fields -->
+<meta property="og:title" content="{{ .Params.title }} | Aflevering {{ .Params.number }}" />
+<meta property="og:site_name" content="{{ .Site.Params.opengraph_sitename }}"/>
+<meta property="og:type" content="website" />
+<meta property="og:url" content="{{ .Permalink }}" />
+<meta property="og:image" content="{{ .Site.BaseURL }}{{ .Site.Params.opengraph_image }}" />
+<meta property="og:description" content="{{ .Params.short_description }}" />
+
+<!-- Twitter Meta Tags -->
+<meta name="twitter:card" content="summary_large_image">
+<meta property="twitter:domain" content="bunzing.org">
+<meta property="twitter:url" content="{{ .Permalink }}">
+<meta name="twitter:title" content="{{ .Params.title }} | Aflevering {{ .Params.number }}">
+<meta name="twitter:description" content="{{ .Params.short_description }}">
+<meta name="twitter:image" content="{{ .Site.BaseURL }}{{ .Site.Params.opengraph_image }}">
+
+{{ else }}
+
 <!-- Open Graph preview fields -->
 <meta property="og:title" content="{{ .Site.Params.opengraph_title }}" />
 <meta property="og:site_name" content="{{ .Site.Params.opengraph_sitename }}"/>
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ .Site.BaseURL }}" />
 <meta property="og:image" content="{{ .Site.BaseURL }}{{ .Site.Params.opengraph_image }}" />
-<!-- <meta property="og:video" content="{{ .Site.BaseURL }}{{ .Site.Params.opengraph_video }}" /> -->
 <meta property="og:description" content="{{ .Site.Params.opengraph_description }}" />
 
 <!-- Twitter Meta Tags -->
@@ -22,6 +40,9 @@
 <meta name="twitter:title" content="{{ .Site.Params.opengraph_title }}">
 <meta name="twitter:description" content="{{ .Site.Params.opengraph_description }}">
 <meta name="twitter:image" content="{{ .Site.BaseURL }}{{ .Site.Params.opengraph_image }}">
+
+{{ end }}
+
 
 <title>
   {{ if .IsHome }}{{ site.Title }}{{ else }}{{ printf "%s | %s" .Title


### PR DESCRIPTION
This adds the OpenGraph meta (conditionally) for the posts as well. The image is still the same, but it presents the title and description of the post, instead of those belonging to the website as a whole. 

Caveats: this does assume that all the posts are podcast episodes. The 'Aflevering' bit is now hardcoded.

It works for now, I think, but as soon as we add other types of posts, we need to make the conditional more specific (or find another way of distinguishing between the desired presentations in the OpenGraph tags). 