### PR TITLE
Replace email w youtube feedback

### DIFF
--- a/themes/flow-theme/layouts/_partials/review.html
+++ b/themes/flow-theme/layouts/_partials/review.html
@@ -11,7 +11,7 @@
       >
         <!-- Spotify -->
         <button class="bg-red-500 text-white hover:bg-red-600 font-semibold py-2 px-4 rounded-full">
-            <a href="https://open.spotify.com/show/0lnivLTo5SVGLNvDmcCkYX">
+            <a href="{{ .Site.Params.spotify }}">
             <span class="flex flex-row justify-center items-center gap-2">
                 <svg
                   aria-hidden="true"
@@ -30,8 +30,7 @@
               </span>
               </a>
           </button>
-  
-  
+    
         <!-- Apple podcasts -->
         <button class="bg-red-500 text-white hover:bg-red-600 font-semibold py-2 px-4 rounded-full">
             <a href="https://geo.itunes.apple.com/nl/podcast/id1820276755">
@@ -52,13 +51,27 @@
               </span>
             </a>
           </button>
-  
-        <!-- Email -->
-     <button class="border-2 border-lime-100 text-lime-100 hover:border-red-600 hover:bg-red-600 hover:text-white font-semibold py-2 px-4 rounded-full">
-        {{ $subject := print "Feedback op " .Site.Params.podcast.title | safeURL }}
-            <a href="mailto:hallo@bunzing.org?subject= {{ $subject }}">Email direct feedback</a>
-          </span>
-      </button>
+
+        <!-- Youtube -->
+        <button class="bg-red-500 text-white hover:bg-red-600 font-semibold py-2 px-4 rounded-full">
+            <a href="{{ .Site.Params.youtube }}">
+            <span class="flex flex-row justify-center items-center gap-2">
+                <svg
+                aria-hidden="true"
+                class="w-8 h-8"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 576 512"
+              >
+                <path
+                  fill="currentColor"
+                  d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z"
+                ></path>
+              </svg>
+                <p>Beoordeel op Youtube</p>
+              </span>
+            </a>
+          </button>    
+
       </div>
     </div>
   </section>


### PR DESCRIPTION
This change replaces the 'Email feedback' button in the reviews CTA section with a button to review the podcast on youtube (a directly link to the youtube channel).